### PR TITLE
Update vocabulary-embedding.ipynb

### DIFF
--- a/vocabulary-embedding.ipynb
+++ b/vocabulary-embedding.ipynb
@@ -422,7 +422,7 @@
     "if not os.path.exists(glove_name):\n",
     "    path = 'glove.6B.zip'\n",
     "    path = get_file(path, origin=\"http://nlp.stanford.edu/data/glove.6B.zip\")\n",
-    "    !unzip {datadir}/{path}"
+    "    !unzip {path}"
    ]
   },
   {


### PR DESCRIPTION
With the following code : 
`!unzip {datadir}/{path}` while executing is producing the following error.
`
unzip:  cannot find or open /home/user_name/.keras/datasets//home/user_name/.keras/datasets/glove.6B.zip, /home/user_name/.keras/datasets//home/user_name/.keras/datasets/glove.6B.zip.zip or /home/user_name/.keras/datasets//home/user_name/.keras/datasets/glove.6B.zip.ZIP. `

Removing `{datadir}` removes the above error and files are extracted successfully. 